### PR TITLE
Fix Content-length header

### DIFF
--- a/invoice.js
+++ b/invoice.js
@@ -10,7 +10,7 @@ function generateInvoice(invoice, filename, success, error) {
         method    : "POST",
         headers   : {
             "Content-Type": "application/json",
-            "Content-Length": postData.length
+            "Content-Length": Buffer.byteLength(postData)
         }
     };
 


### PR DESCRIPTION
The best method to compute the "Content-Length" is by using ``Buffer.byteLength()``.  

The length of a string is not necessarily equal to the number of bytes contained in that string. The byte length depends on the string encoding. UTF-8 uses multiple bytes to encode characters outside the 7-bit ASCII range (0 - 127). Accented characters fall outside that range.

See here:
http://stackoverflow.com/questions/17922748/what-is-the-correct-method-for-calculating-the-content-length-header-in-node-js